### PR TITLE
Add test cases from the Allen (1983) paper

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -45,6 +45,11 @@ main = do
     test prop_intervalAssume
     test prop_intervalAllBitsDefault
 
+    putStrLn "\nTests from Allen (1983)...\n"
+
+    test prop_Section4Subsection2
+
+
 -- Throw error on test failure so that 
 -- Spec.hs can properly recognize that a test has failed.
 test :: Testable prop => prop -> IO ()
@@ -95,4 +100,27 @@ prop_intervalAllBitsDefault = evalAllen calc
             c2 <- getConstraints b a
 
             return (c1 == c2 && c1 == allRelationBits)
+
+-- Examples from Section 4.2 of the Allen (1983) paper.
+prop_Section4Subsection2 :: Bool
+prop_Section4Subsection2 = evalAllen calc
+    where calc :: Allen Bool
+          calc = do
+            r <- interval
+            s <- interval
+            l <- interval
+
+            -- srRelationSet <- relationUnion $ map toBits [Precedes, Meets, MetBy, PrecededBy] 
+            -- slRelationSet <- relationUnion $ map toBits [Overlaps, Meets]
+            srRelationBits <- bitsFromString "pmMP" 
+            slRelationBits <- bitsFromString "om"
+
+            assumeBits s srRelationBits r
+            assumeBits s slRelationBits l
+
+            lrRelationBits <- getConstraints l r
+            -- expected <- relationUnion $ map toBits [Precedes, PrecededBy, Overlaps, Meets, Contains, Starts, StartedBy, FinishedBy, Equals]
+            expectedBits <- bitsFromString "pPomDsSFe"
+
+            return (lrRelationBits == expectedBits)
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -47,7 +47,9 @@ main = do
 
     putStrLn "\nTests from Allen (1983)...\n"
 
-    test prop_Section4Subsection2
+    test prop_Section4Subsection2Part1
+    test prop_Section4Subsection2Part2
+    test prop_Section4Subsection2Part3
 
 
 -- Throw error on test failure so that 
@@ -101,26 +103,90 @@ prop_intervalAllBitsDefault = evalAllen calc
 
             return (c1 == c2 && c1 == allRelationBits)
 
+--
 -- Examples from Section 4.2 of the Allen (1983) paper.
-prop_Section4Subsection2 :: Bool
-prop_Section4Subsection2 = evalAllen calc
+--
+
+-- First inference from Section 4.2
+prop_Section4Subsection2Part1 :: Bool
+prop_Section4Subsection2Part1 = evalAllen calc
     where calc :: Allen Bool
           calc = do
+            -- Set up basic network.
             r <- interval
             s <- interval
             l <- interval
-
-            -- srRelationSet <- relationUnion $ map toBits [Precedes, Meets, MetBy, PrecededBy] 
-            -- slRelationSet <- relationUnion $ map toBits [Overlaps, Meets]
-            srRelationBits <- bitsFromString "pmMP" 
-            slRelationBits <- bitsFromString "om"
-
+            -- srRelationSet [Precedes, Meets, MetBy, PrecededBy] 
+            -- slRelationSet [Overlaps, Meets]
+            let srRelationBits = bitsFromString "pmMP" 
+                slRelationBits = bitsFromString "om"
             assumeBits s srRelationBits r
             assumeBits s slRelationBits l
 
-            lrRelationBits <- getConstraints l r
-            -- expected <- relationUnion $ map toBits [Precedes, PrecededBy, Overlaps, Meets, Contains, Starts, StartedBy, FinishedBy, Equals]
-            expectedBits <- bitsFromString "pPomDsSFe"
+            lrInferredBits <- getConstraints l r
+            -- expected [Precedes, PrecededBy, Overlaps, Meets, Contains, Starts, StartedBy, FinishedBy, Equals]
+            let lrExpectedBits = bitsFromString "pPomDsSFe"
 
-            return (lrRelationBits == expectedBits)
+            return (lrInferredBits == lrExpectedBits)
+
+-- Additional inference from Section 4.2.
+-- Assumes part 1 inference works.
+prop_Section4Subsection2Part2 :: Bool
+prop_Section4Subsection2Part2 = evalAllen calc
+    where calc :: Allen Bool
+          calc = do
+            -- Set up same network as Part 1, but with added l->r relations.
+            r <- interval
+            s <- interval
+            l <- interval
+            -- lrRelationSet [Overlaps, Starts, During]
+            let srRelationBits = bitsFromString "pmMP" 
+                slRelationBits = bitsFromString "om"
+                lrRelationBits = bitsFromString "osd"
+            assumeBits s srRelationBits r
+            assumeBits s slRelationBits l
+            assumeBits l lrRelationBits r
+
+            lrInferredBits <- getConstraints l r
+            srInferredBits <- getConstraints s r
+            -- lrExpected [Overlaps, Starts]
+            -- srExpected [Precedes, Meets]
+            let lrExpectedBits = bitsFromString "os"
+                srExpectedBits = bitsFromString "pm"
+
+            return (lrInferredBits == lrExpectedBits
+                 && srInferredBits == srExpectedBits)
+
+-- Final inference from Section 4.2.
+-- Assumes inferences from parts 1 and 2 works.
+prop_Section4Subsection2Part3 :: Bool
+prop_Section4Subsection2Part3 = evalAllen calc
+    where calc :: Allen Bool
+          calc = do
+            -- Set up same network as Part 2.
+            r <- interval
+            s <- interval
+            l <- interval
+            let srRelationBits = bitsFromString "pmMP" 
+                slRelationBits = bitsFromString "om"
+                lrRelationBits = bitsFromString "osd"
+            assumeBits s srRelationBits r
+            assumeBits s slRelationBits l
+            assumeBits l lrRelationBits r
+
+            -- Add new interval D
+            -- w/ D -[During]-> S
+            d <- interval
+            let dsRelationBits = bitsFromString "d"
+            assumeBits d dsRelationBits s
+
+            drInferredBits <- getConstraints d r
+            dlInferredBits <- getConstraints d l
+            -- drExpected [Precedes]
+            -- dlExpected [Precedes, Overlaps, Meets, During, Starts]
+            let drExpectedBits = bitsFromString "p"
+                dlExpectedBits = bitsFromString "pomds"
+
+            return (drInferredBits == drExpectedBits
+                 && dlInferredBits == dlExpectedBits)
 


### PR DESCRIPTION
I tried writing a test case, but it keeps failing to compile. And due to my limited recent experience with Haskell, I'm having trouble figuring out what I'm doing wrong. Adam, could you take a look and let me know how I might fix this test case? Below is the error message in case that helps.

```
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - allen-0.1.0.0 (test:allen-test) (file test/Spec.hs changed)
Preprocessing test suite 'allen-test' for allen-0.1.0.0..
Building test suite 'allen-test' for allen-0.1.0.0..
[2 of 2] Compiling Main             ( test/Spec.hs, /mnt/c/Users/genel/code/allen/dist-newstyle/build/x86_64-linux/ghc-8.6.5/allen-0.1.0.0/t/allen-test/build/allen-test/allen-test-tmp/Main.o )

test/Spec.hs:115:31: error:
    • Couldn't match type ‘GHC.Word.Word16’
                     with ‘transformers-0.5.6.2:Control.Monad.Trans.State.Lazy.StateT
                             IntervalGraph Data.Functor.Identity.Identity RelationBits’
      Expected type: transformers-0.5.6.2:Control.Monad.Trans.State.Lazy.StateT
                       IntervalGraph Data.Functor.Identity.Identity RelationBits
        Actual type: RelationBits
    • In a stmt of a 'do' block:
        srRelationBits <- bitsFromString "pmMP"
      In the expression:
        do r <- interval
           s <- interval
           l <- interval
           srRelationBits <- bitsFromString "pmMP"
           ....
      In an equation for ‘calc’:
          calc
            = do r <- interval
                 s <- interval
                 l <- interval
                 ....
    |
115 |             srRelationBits <- bitsFromString "pmMP"
    |                               ^^^^^^^^^^^^^^^^^^^^^

test/Spec.hs:116:31: error:
    • Couldn't match type ‘GHC.Word.Word16’
                     with ‘transformers-0.5.6.2:Control.Monad.Trans.State.Lazy.StateT
                             IntervalGraph Data.Functor.Identity.Identity RelationBits’
      Expected type: transformers-0.5.6.2:Control.Monad.Trans.State.Lazy.StateT
                       IntervalGraph Data.Functor.Identity.Identity RelationBits
        Actual type: RelationBits
    • In a stmt of a 'do' block: slRelationBits <- bitsFromString "om"
      In the expression:
        do r <- interval
           s <- interval

           l <- interval
           srRelationBits <- bitsFromString "pmMP"
           ....
      In an equation for ‘calc’:
          calc
            = do r <- interval
                 s <- interval
                 l <- interval
                 ....
    |
116 |             slRelationBits <- bitsFromString "om"
    |                               ^^^^^^^^^^^^^^^^^^^

test/Spec.hs:123:29: error:
    • Couldn't match type ‘GHC.Word.Word16’
                     with ‘transformers-0.5.6.2:Control.Monad.Trans.State.Lazy.StateT
                             IntervalGraph Data.Functor.Identity.Identity RelationBits’
      Expected type: transformers-0.5.6.2:Control.Monad.Trans.State.Lazy.StateT
                       IntervalGraph Data.Functor.Identity.Identity RelationBits
        Actual type: RelationBits
    • In a stmt of a 'do' block:
        expectedBits <- bitsFromString "pPomDsSFe"
      In the expression:
        do r <- interval
           s <- interval
           l <- interval
           srRelationBits <- bitsFromString "pmMP"
           ....
      In an equation for ‘calc’:
          calc
            = do r <- interval
                 s <- interval
                 l <- interval
                 ....
    |
123 |             expectedBits <- bitsFromString "pPomDsSFe"
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
```