### PR TITLE
Json parsing

### DIFF
--- a/allen.cabal
+++ b/allen.cabal
@@ -54,10 +54,10 @@ executable allen-calculator
       aeson >=2.1.2 && <2.2
     , allen
     , base >=4.7 && <5
-    , bytestring >=0.10.12 && <0.11
+    , bytestring >=0.11.2.0 && <0.12
     , containers >=0.6.4 && <0.7
     , mtl >=2.2.2 && <2.3
-    , text >=1.2.5 && <1.3
+    , text ==2.0.2.*
     , vector >=0.13.0 && <0.14
   default-language: Haskell2010
 

--- a/allen.cabal
+++ b/allen.cabal
@@ -51,7 +51,8 @@ executable allen-calculator
       app
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      allen
+      aeson
+    , allen
     , base >=4.7 && <5
     , containers
     , mtl

--- a/allen.cabal
+++ b/allen.cabal
@@ -38,8 +38,10 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
+    , bytestring
     , containers
     , mtl
+    , text
     , vector
   default-language: Haskell2010
 
@@ -54,8 +56,10 @@ executable allen-calculator
       aeson
     , allen
     , base >=4.7 && <5
+    , bytestring
     , containers
     , mtl
+    , text
     , vector
   default-language: Haskell2010
 
@@ -71,8 +75,10 @@ test-suite allen-test
       QuickCheck
     , allen
     , base >=4.7 && <5
+    , bytestring
     , containers
     , mtl
+    , text
     , vector
   default-language: Haskell2010
 
@@ -87,8 +93,10 @@ benchmark allen-benchmarks
   build-depends:
       allen
     , base >=4.7 && <5
+    , bytestring
     , containers
     , criterion
     , mtl
+    , text
     , vector
   default-language: Haskell2010

--- a/allen.cabal
+++ b/allen.cabal
@@ -38,11 +38,9 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
-    , bytestring
-    , containers
-    , mtl
-    , text
-    , vector
+    , containers >=0.6.4 && <0.7
+    , mtl >=2.2.2 && <2.3
+    , vector >=0.13.0 && <0.14
   default-language: Haskell2010
 
 executable allen-calculator
@@ -53,14 +51,14 @@ executable allen-calculator
       app
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson
+      aeson >=2.1.2 && <2.2
     , allen
     , base >=4.7 && <5
-    , bytestring
-    , containers
-    , mtl
-    , text
-    , vector
+    , bytestring >=0.10.12 && <0.11
+    , containers >=0.6.4 && <0.7
+    , mtl >=2.2.2 && <2.3
+    , text >=1.2.5 && <1.3
+    , vector >=0.13.0 && <0.14
   default-language: Haskell2010
 
 test-suite allen-test
@@ -72,14 +70,12 @@ test-suite allen-test
       test
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      QuickCheck
+      QuickCheck >=2.14.3 && <2.15
     , allen
     , base >=4.7 && <5
-    , bytestring
-    , containers
-    , mtl
-    , text
-    , vector
+    , containers >=0.6.4 && <0.7
+    , mtl >=2.2.2 && <2.3
+    , vector >=0.13.0 && <0.14
   default-language: Haskell2010
 
 benchmark allen-benchmarks
@@ -93,10 +89,8 @@ benchmark allen-benchmarks
   build-depends:
       allen
     , base >=4.7 && <5
-    , bytestring
-    , containers
-    , criterion
-    , mtl
-    , text
-    , vector
+    , containers >=0.6.4 && <0.7
+    , criterion >=1.6.2 && <1.7
+    , mtl >=2.2.2 && <2.3
+    , vector >=0.13.0 && <0.14
   default-language: Haskell2010

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,10 +17,10 @@ import System.IO
 
 data RelationJSON = RelationJSON { realtionFrom :: String 
                                  , relationTo   :: String 
-                                 , relBits      :: Int
+                                 , relChars     :: String
                                  }
 
-data NetworkJSON = NetworkJSON { ivNames   :: [String] 
+data NetworkJSON = NetworkJSON { ivNames   :: [String]
                                , relations :: [RelationJSON]
                                }
 
@@ -28,7 +28,7 @@ instance FromJSON RelationJSON where
     parseJSON = withObject "RelationJSON" $ \v -> RelationJSON 
         <$> v .: "from"
         <*> v .: "to"
-        <*> v .: "bits"
+        <*> v .: "relation"
 
 instance FromJSON NetworkJSON where 
     parseJSON = withObject "NetworkJSON" $ \v -> NetworkJSON 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main (main) where
 
 import Control.Monad
 import Control.Monad.State
 
+import Data.Aeson
 import Data.Allen
 import Data.List (sortBy)
 import Data.Ord (comparing)
@@ -11,6 +14,26 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 
 import System.IO
+
+data RelationJSON = RelationJSON { realtionFrom :: String 
+                                 , relationTo   :: String 
+                                 , relBits      :: Int
+                                 }
+
+data NetworkJSON = NetworkJSON { ivNames   :: [String] 
+                               , relations :: [RelationJSON]
+                               }
+
+instance FromJSON RelationJSON where 
+    parseJSON = withObject "RelationJSON" $ \v -> RelationJSON 
+        <$> v .: "from"
+        <*> v .: "to"
+        <*> v .: "bits"
+
+instance FromJSON NetworkJSON where 
+    parseJSON = withObject "NetworkJSON" $ \v -> NetworkJSON 
+        <$> v .: "intervals" 
+        <*> v .: "relations"
 
 data REPLState = REPLState { graph :: Allen (), intervalNames :: Map String IntervalID }
 type REPL = StateT REPLState IO

--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,6 @@ dependencies:
 - mtl
 - vector
 - containers
-- bytestring
 - text
 
 ghc-options:
@@ -54,6 +53,7 @@ executables:
     dependencies:
     - allen
     - aeson
+    - bytestring
 
 tests:
   allen-test:

--- a/package.yaml
+++ b/package.yaml
@@ -23,10 +23,9 @@ description:         Please see the README on GitHub at <https://github.com/arch
 
 dependencies:
 - base >= 4.7 && < 5
-- mtl
-- vector
-- containers
-- text
+- mtl >= 2.2.2 && < 2.3
+- vector >= 0.13.0 && < 0.14
+- containers >= 0.6.4 && < 0.7
 
 ghc-options:
 - -Wall
@@ -52,8 +51,9 @@ executables:
     - -with-rtsopts=-N
     dependencies:
     - allen
-    - aeson
-    - bytestring
+    - aeson >= 2.1.2 && < 2.2
+    - bytestring >= 0.10.12 && < 0.11
+    - text >= 1.2.5 && < 1.3
 
 tests:
   allen-test:
@@ -65,7 +65,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - allen
-    - QuickCheck
+    - QuickCheck >= 2.14.3 && < 2.15
 
 benchmarks:
   allen-benchmarks:
@@ -77,4 +77,4 @@ benchmarks:
     - -with-rtsopts=-N
     dependencies: 
     - allen
-    - criterion
+    - criterion >= 1.6.2 && < 1.7

--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,7 @@ executables:
     - -with-rtsopts=-N
     dependencies:
     - allen
+    - aeson
 
 tests:
   allen-test:

--- a/package.yaml
+++ b/package.yaml
@@ -52,8 +52,8 @@ executables:
     dependencies:
     - allen
     - aeson >= 2.1.2 && < 2.2
-    - bytestring >= 0.10.12 && < 0.11
-    - text >= 1.2.5 && < 1.3
+    - bytestring >= 0.11.2.0 && < 0.12
+    - text >= 2.0.2 && < 2.0.3
 
 tests:
   allen-test:

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,8 @@ dependencies:
 - mtl
 - vector
 - containers
+- bytestring
+- text
 
 ghc-options:
 - -Wall


### PR DESCRIPTION
This gives the interactive REPL the ability to also be used as a command line utility to use JSON files for calculations. Due to the nature of the interval algebra notation, interval IDs **MUST** follow the numbering system (intervals are numbered according to the order they were created). I will see about using string representations in the future, but this may require a large rewrite of everything. 

Here is an example of how to use it using Section 4.2 Part 1 test:

There would be a file `in.json` with the following contents:

```json
{
  "intervals": 3,
  "relations": [
    {
      "from": 1,
      "to": 0,
      "relation": "pmMP"
    },
    {
      "from": 1
      "to": 2
      "relation": "om"
    }
  ]
}
```

The executable would then be used with the command:

```
allen-calculator in.json out.json
```

And the resulting JSON file would look like :

```json
{"intervals":[{"id":0,"relations":[{"from":1,"relation":"pmMP","to":2},{"from":2,"relation":"pseSdfOMP","to":3}]},{"id":1,"relations":[{"from":0,"relation":"pmMP","to":1},{"from":2,"relation":"mo","to":3}]},{"id":2,"relations":[{"from":0,"relation":"pmoFDseSP","to":1},{"from":1,"relation":"OM","to":2}]}]}
```

You can paste into [here](https://codebeautify.org/json-decode-online) for a better visual.